### PR TITLE
trap when registrator shuts down and explicitly deregister any containers running on this instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM gliderlabs/registrator:v7
-MAINTAINER Dwolla Platform Team
-ADD registrator_on_ec2_hostname.sh /usr/local/bin/registrator_on_ec2_hostname.sh
-RUN apk-install curl
+LABEL maintainer="Dwolla Platform Team"
+COPY registrator_on_ec2_hostname.sh /usr/local/bin/registrator_on_ec2_hostname.sh
+RUN apk-install bash curl jq
 ENTRYPOINT ["registrator_on_ec2_hostname.sh"]

--- a/registrator_on_ec2_hostname.sh
+++ b/registrator_on_ec2_hostname.sh
@@ -1,4 +1,19 @@
-#!/bin/sh
-export LOCAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
-echo Running: registrator -ip $LOCAL_IP $@ consul://$LOCAL_IP:8500
-exec registrator -ip $LOCAL_IP "$@" consul://$LOCAL_IP:8500
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+IFS=$'\n\t'
+
+function deregister {
+  registrator_exit_code=$?
+  echo "Registrator has exited; cleaning up containers registered on this instance" > /dev/stderr
+  set -o xtrace
+  curl --silent "http://${LOCAL_IP}:8500/v1/agent/services" | \
+    jq -r "map(\"http://${LOCAL_IP}:8500/v1/agent/service/deregister/\(.ID)\") | .[]" | \
+    xargs curl --silent --verbose -XPUT
+  exit ${registrator_exit_code}
+}
+trap deregister EXIT
+
+LOCAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+export LOCAL_IP
+echo "Running: registrator -ip ${LOCAL_IP} $* consul://$LOCAL_IP:8500" > /dev/stderr
+registrator -ip "${LOCAL_IP}" "$@" "consul://${LOCAL_IP}:8500"


### PR DESCRIPTION
Right now when ECS runs Registrator as a daemon, it may be stopped prior to other containers on the EC2 instance. That means when those other containers are stopped, nothing deregisters them from Consul until the instance itself shuts down and is removed altogether as a node. 

This will deregister all the services registered via the Consul agent running on the instance when Registrator shuts down.